### PR TITLE
Update JavaScript SDK for Vercel AI SDK 7

### DIFF
--- a/packages/manageprompt-js/README.md
+++ b/packages/manageprompt-js/README.md
@@ -25,6 +25,8 @@ pnpm add manageprompt
 
 ### Vercel AI SDK Middleware (Recommended)
 
+This integration supports Vercel AI SDK 7 and requires Node.js 22 or later.
+
 ```ts
 import { generateText, wrapLanguageModel } from "ai";
 import { openai } from "@ai-sdk/openai";
@@ -39,6 +41,26 @@ const { text } = await generateText({ model, prompt: "Hello" });
 ```
 
 Works with any AI SDK provider — OpenAI, Anthropic, Google, Mistral, etc.
+
+#### Test the integration locally
+
+Start ManagePrompt from the repository root:
+
+```bash
+go run ./cmd/manageprompt start
+```
+
+In another terminal, build the package and run the example with an OpenAI API key:
+
+```bash
+cd packages/manageprompt-js
+pnpm build
+OPENAI_API_KEY=your-key pnpm example:vercel-ai
+```
+
+The example makes one generated and one streamed request. Open
+`http://localhost:54321` and verify both calls show the prompt, response, token
+usage, latency, finish reason, and correct streaming status.
 
 ### capture()
 

--- a/packages/manageprompt-js/examples/vercel-ai-sdk.ts
+++ b/packages/manageprompt-js/examples/vercel-ai-sdk.ts
@@ -1,0 +1,29 @@
+import { openai } from "@ai-sdk/openai";
+import { generateText, streamText, wrapLanguageModel } from "ai";
+import { devToolsMiddleware } from "manageprompt";
+
+const model = wrapLanguageModel({
+  model: openai("gpt-4o-mini"),
+  middleware: devToolsMiddleware(),
+});
+
+const generated = await generateText({
+  model,
+  prompt: "Say hello from the non-streaming ManagePrompt example in one sentence.",
+});
+
+console.log("Generated response:", generated.text);
+
+const streamed = streamText({
+  model,
+  prompt: "Say hello from the streaming ManagePrompt example in one sentence.",
+});
+
+process.stdout.write("Streaming response: ");
+for await (const text of streamed.textStream) {
+  process.stdout.write(text);
+}
+process.stdout.write("\n");
+
+await new Promise((resolve) => setTimeout(resolve, 500));
+console.log("Open http://localhost:54321 to inspect both requests.");

--- a/packages/manageprompt-js/package.json
+++ b/packages/manageprompt-js/package.json
@@ -27,7 +27,7 @@
     "test:capture-anthropic": "tsx tests/test-capture-anthropic.ts"
   },
   "peerDependencies": {
-    "@ai-sdk/provider": ">=3.0.0"
+    "@ai-sdk/provider": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/provider": {
@@ -35,14 +35,14 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^3.0.46",
-    "@ai-sdk/openai": "^3.0.30",
-    "@ai-sdk/provider": "^3.0.8",
+    "@ai-sdk/anthropic": "^4.0.38",
+    "@ai-sdk/openai": "^4.0.40",
+    "@ai-sdk/provider": "^4.0.7",
     "@anthropic-ai/sdk": "^0.39.0",
-    "@openrouter/ai-sdk-provider": "^2.2.3",
+    "@openrouter/ai-sdk-provider": "^3.0.0",
     "@rollup/plugin-typescript": "^12.1.0",
     "@types/node": "^25.3.0",
-    "ai": "^6.0.97",
+    "ai": "^7.0.62",
     "openai": "^4.80.0",
     "rollup": "^4.30.0",
     "rollup-plugin-dts": "^6.2.0",

--- a/packages/manageprompt-js/package.json
+++ b/packages/manageprompt-js/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "example:vercel-ai": "tsx examples/vercel-ai-sdk.ts",
     "test:openai": "tsx tests/test-openai.ts",
     "test:anthropic": "tsx tests/test-anthropic.ts",
     "test:openrouter": "tsx tests/test-openrouter.ts",

--- a/packages/manageprompt-js/pnpm-lock.yaml
+++ b/packages/manageprompt-js/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.46
-        version: 3.0.46(zod@4.3.6)
+        specifier: ^4.0.38
+        version: 4.0.38(zod@4.3.6)
       '@ai-sdk/openai':
-        specifier: ^3.0.30
-        version: 3.0.30(zod@4.3.6)
+        specifier: ^4.0.40
+        version: 4.0.40(zod@4.3.6)
       '@ai-sdk/provider':
-        specifier: ^3.0.8
-        version: 3.0.8
+        specifier: ^4.0.7
+        version: 4.0.7
       '@anthropic-ai/sdk':
         specifier: ^0.39.0
         version: 0.39.0
       '@openrouter/ai-sdk-provider':
-        specifier: ^2.2.3
-        version: 2.2.3(ai@6.0.97(zod@4.3.6))(zod@4.3.6)
+        specifier: ^3.0.0
+        version: 3.0.0(ai@7.0.62(zod@4.3.6))(zod@4.3.6)
       '@rollup/plugin-typescript':
         specifier: ^12.1.0
         version: 12.3.0(rollup@4.58.0)(tslib@2.8.1)(typescript@5.9.3)
@@ -30,8 +30,8 @@ importers:
         specifier: ^25.3.0
         version: 25.3.0
       ai:
-        specifier: ^6.0.97
-        version: 6.0.97(zod@4.3.6)
+        specifier: ^7.0.62
+        version: 7.0.62(zod@4.3.6)
       openai:
         specifier: ^4.80.0
         version: 4.104.0(zod@4.3.6)
@@ -56,33 +56,33 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@3.0.46':
-    resolution: {integrity: sha512-zXJPiNHaIiQ6XUqLeSYZ3ZbSzjqt1pNWEUf2hlkXlmmw8IF8KI0ruuGaDwKCExmtuNRf0E4TDxhsc9wRgWTzpw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/anthropic@4.0.38':
+    resolution: {integrity: sha512-esbTb5jq/37dloBJzld3CpYCZskiDWGcI4O8kzst9J/0Km4by7cgQXLTB/gGdjXxBsyjPQUeotVqqRRIrx2zew==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.53':
-    resolution: {integrity: sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.49':
+    resolution: {integrity: sha512-qdSUr4FAN7e+MHBdVzkmbGMtpf7XQdQp1AgMI3jV0QPmld/4k4QbR7mXRQgjUsPeIfAwBzMPMPziHAPP1tXRwg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.30':
-    resolution: {integrity: sha512-YDht3t7TDyWKP+JYZp20VuYqSjyF2brHYh47GGFDUPf2wZiqNQ263ecL+quar2bP3GZ3BeQA8f0m2B7UwLPR+g==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai@4.0.40':
+    resolution: {integrity: sha512-efidMH4glnomQM8XtAAmL7tn06D1YvBeqXRE0qCEcDamvpEGrROJePxCq+31L5BnuglngWW2ZapddCoshJ0kMA==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.15':
-    resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
 
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
@@ -254,16 +254,12 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@openrouter/ai-sdk-provider@2.2.3':
-    resolution: {integrity: sha512-NovC+BaCfEeJwhToDrs8JeDYXXlJdEyz7lcxkjtyePSE4eoAKik872SyDK0MzXKcz8MRkv7XlNhPI6zz4TQp0g==}
-    engines: {node: '>=18'}
+  '@openrouter/ai-sdk-provider@3.0.0':
+    resolution: {integrity: sha512-m9XTSWoODH2RM5OsZpaGiN7QRR8cdP5paBWq699Tu3JVmGPBKT8xF8XwV0ZBVVsjikD/JgWfak4VSsTR4wAVbg==}
+    engines: {node: '>=22'}
     peerDependencies:
-      ai: ^6.0.0
-      zod: ^3.25.0 || ^4.0.0
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
+      ai: ^7.0.0
+      zod: ^3.25.76 || ^4.1.8
 
   '@rollup/plugin-typescript@12.3.0':
     resolution: {integrity: sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==}
@@ -440,9 +436,12 @@ packages:
   '@types/node@25.3.0':
     resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -452,9 +451,9 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@6.0.97:
-    resolution: {integrity: sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==}
-    engines: {node: '>=18'}
+  ai@7.0.62:
+    resolution: {integrity: sha512-/YiuaaFIUPAiGqzHphnu9NuHQKbToZjlZkKoqGsQx6TFd7CZj6Z3eQUNeK6er1kXb9Ou5hRntRX4dvvE/kHYiQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -505,8 +504,8 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
   form-data-encoder@1.7.2:
@@ -668,6 +667,10 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
@@ -683,33 +686,35 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@3.0.46(zod@4.3.6)':
+  '@ai-sdk/anthropic@4.0.38(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.53(zod@4.3.6)':
+  '@ai-sdk/gateway@4.0.49(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.30(zod@4.3.6)':
+  '@ai-sdk/openai@4.0.40(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@4.0.15(zod@4.3.6)':
+  '@ai-sdk/provider-utils@5.0.27(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
       zod: 4.3.6
 
-  '@ai-sdk/provider@3.0.8':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -815,12 +820,10 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@openrouter/ai-sdk-provider@2.2.3(ai@6.0.97(zod@4.3.6))(zod@4.3.6)':
+  '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.62(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      ai: 6.0.97(zod@4.3.6)
+      ai: 7.0.62(zod@4.3.6)
       zod: 4.3.6
-
-  '@opentelemetry/api@1.9.0': {}
 
   '@rollup/plugin-typescript@12.3.0(rollup@4.58.0)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
@@ -931,7 +934,9 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
+
+  '@workflow/serde@4.1.0': {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -941,12 +946,11 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@6.0.97(zod@4.3.6):
+  ai@7.0.62(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.53(zod@4.3.6)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 4.0.49(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.3.6)
       zod: 4.3.6
 
   asynckit@0.4.0: {}
@@ -1016,7 +1020,7 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.1.1: {}
 
   form-data-encoder@1.7.2: {}
 
@@ -1191,6 +1195,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@7.18.2: {}
+
+  undici@7.29.0: {}
 
   web-streams-polyfill@4.0.0-beta.3: {}
 

--- a/packages/manageprompt-js/src/index.ts
+++ b/packages/manageprompt-js/src/index.ts
@@ -1,19 +1,19 @@
 import type {
-  LanguageModelV3Middleware,
-  LanguageModelV3StreamPart,
-  LanguageModelV3CallOptions,
-  LanguageModelV3,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamResult,
-  LanguageModelV3Usage,
-  LanguageModelV3FinishReason,
+  LanguageModelV4Middleware,
+  LanguageModelV4StreamPart,
+  LanguageModelV4CallOptions,
+  LanguageModelV4,
+  LanguageModelV4GenerateResult,
+  LanguageModelV4StreamResult,
+  LanguageModelV4Usage,
+  LanguageModelV4FinishReason,
 } from "@ai-sdk/provider";
 
 type ManagePromptOptions = {
   url?: string;
 };
 
-function extractText(content: LanguageModelV3GenerateResult["content"]): string {
+function extractText(content: LanguageModelV4GenerateResult["content"]): string {
   return content
     .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
     .map((part) => part.text)
@@ -34,7 +34,7 @@ function extractCost(providerMetadata: unknown): number | undefined {
   return meta?.openrouter?.usage?.costDetails?.upstreamInferenceCost ?? undefined;
 }
 
-function extractUsage(usage: LanguageModelV3Usage) {
+function extractUsage(usage: LanguageModelV4Usage) {
   const tokensInput =
     usage.inputTokens.total ??
     (sum(usage.inputTokens.noCache, usage.inputTokens.cacheRead, usage.inputTokens.cacheWrite) || undefined);
@@ -53,14 +53,14 @@ function extractUsage(usage: LanguageModelV3Usage) {
 
 export function devToolsMiddleware(
   options?: ManagePromptOptions
-): LanguageModelV3Middleware {
+): LanguageModelV4Middleware {
   const baseURL = (options?.url ?? "http://localhost:54321").replace(/\/$/, "");
 
   let pendingTimer: ReturnType<typeof setTimeout> | null = null;
-  let allChunks: LanguageModelV3StreamPart[] = [];
+  let allChunks: LanguageModelV4StreamPart[] = [];
   let allText = "";
-  let lastUsage: LanguageModelV3Usage | null = null;
-  let lastFinishReason: LanguageModelV3FinishReason | null = null;
+  let lastUsage: LanguageModelV4Usage | null = null;
+  let lastFinishReason: LanguageModelV4FinishReason | null = null;
   let lastCostUSD: number | undefined;
   let streamStart = 0;
   let lastModel = "";
@@ -90,16 +90,16 @@ export function devToolsMiddleware(
   }
 
   return {
-    specificationVersion: "v3",
+    specificationVersion: "v4",
 
     wrapGenerate: async ({
       doGenerate,
       params,
       model,
     }: {
-      doGenerate: () => PromiseLike<LanguageModelV3GenerateResult>;
-      params: LanguageModelV3CallOptions;
-      model: LanguageModelV3;
+      doGenerate: () => PromiseLike<LanguageModelV4GenerateResult>;
+      params: LanguageModelV4CallOptions;
+      model: LanguageModelV4;
     }) => {
       const start = Date.now();
       const result = await doGenerate();
@@ -126,9 +126,9 @@ export function devToolsMiddleware(
       params,
       model,
     }: {
-      doStream: () => PromiseLike<LanguageModelV3StreamResult>;
-      params: LanguageModelV3CallOptions;
-      model: LanguageModelV3;
+      doStream: () => PromiseLike<LanguageModelV4StreamResult>;
+      params: LanguageModelV4CallOptions;
+      model: LanguageModelV4;
     }) => {
       if (streamStart === 0) streamStart = Date.now();
       lastModel = model.modelId;
@@ -143,8 +143,8 @@ export function devToolsMiddleware(
       const { stream, ...rest } = await doStream();
 
       const transform = new TransformStream<
-        LanguageModelV3StreamPart,
-        LanguageModelV3StreamPart
+        LanguageModelV4StreamPart,
+        LanguageModelV4StreamPart
       >({
         transform(chunk, controller) {
           allChunks.push(chunk);

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -18,7 +18,7 @@
     --error: #dc2626;
     --warning: #d97706;
     --highlight: #7c3aed;
-    --font-mono: "Geist Mono", "JetBrains Mono", "SF Mono", "Fira Code", ui-monospace, monospace;
+    --font-mono: monospace;
 }
 
 html {

--- a/web/static/js/apply-settings.js
+++ b/web/static/js/apply-settings.js
@@ -1,8 +1,4 @@
 (function () {
-  function sanitizeFontFamily(value) {
-    return value.replace(/[{};<>]/g, "").trim();
-  }
-
   function normalizeFontSize(value) {
     var size = value.trim().toLowerCase();
     if (!size) return "";
@@ -18,32 +14,19 @@
     return "";
   }
 
-  function buildCustomSettingsCss(family, size) {
-    var css = "";
-
-    if (family) {
-      var fv = family + ", ui-monospace, monospace";
-      css += ":root{--font-mono:" + fv + "}";
-      css += "*{font-family:" + fv + " !important}";
-    }
-
-    if (size) {
-      css += "html{-webkit-text-size-adjust:100%;text-size-adjust:100%}";
-      css += "*{font-size:" + size + " !important}";
-    }
-
-    return css;
+  function buildCustomSettingsCss(size) {
+    return "html{-webkit-text-size-adjust:100%;text-size-adjust:100%}" +
+      "*{font-size:" + size + " !important}";
   }
 
-  var family = sanitizeFontFamily(localStorage.getItem("mp-font-family") || "");
   var size = normalizeFontSize(localStorage.getItem("mp-font-size") || "");
-  if (!family && !size) return;
+  if (!size) return;
 
   var existing = document.getElementById("mp-custom-settings");
   if (existing) existing.remove();
 
   var style = document.createElement("style");
   style.setAttribute("id", "mp-custom-settings");
-  style.textContent = buildCustomSettingsCss(family, size);
+  style.textContent = buildCustomSettingsCss(size);
   document.head.appendChild(style);
 })();

--- a/web/static/js/settings.js
+++ b/web/static/js/settings.js
@@ -1,19 +1,9 @@
 (function () {
-  var familyInput = document.getElementById("font-family");
   var sizeInput = document.getElementById("font-size");
-  var savedFamily = localStorage.getItem("mp-font-family");
   var savedSize = localStorage.getItem("mp-font-size");
-
-  if (savedFamily) {
-    familyInput.value = savedFamily;
-  }
 
   if (savedSize) {
     sizeInput.value = savedSize;
-  }
-
-  function sanitizeFontFamily(value) {
-    return value.replace(/[{};<>]/g, "").trim();
   }
 
   function normalizeFontSize(value) {
@@ -31,34 +21,15 @@
     return "";
   }
 
-  function buildCustomSettingsCss(family, size) {
-    var css = "";
-
-    if (family) {
-      var fv = family + ", ui-monospace, monospace";
-      css += ":root{--font-mono:" + fv + "}";
-      css += "*{font-family:" + fv + " !important}";
-    }
-
-    if (size) {
-      css += "html{-webkit-text-size-adjust:100%;text-size-adjust:100%}";
-      css += "*{font-size:" + size + " !important}";
-    }
-
-    return css;
+  function buildCustomSettingsCss(size) {
+    return "html{-webkit-text-size-adjust:100%;text-size-adjust:100%}" +
+      "*{font-size:" + size + " !important}";
   }
 
   function applySettings() {
-    var family = sanitizeFontFamily(familyInput.value);
     var rawSize = sizeInput.value.trim();
     var normalizedSize = normalizeFontSize(rawSize);
     var invalidSize = rawSize && !normalizedSize;
-
-    if (family) {
-      localStorage.setItem("mp-font-family", family);
-    } else {
-      localStorage.removeItem("mp-font-family");
-    }
 
     if (invalidSize) {
       sizeInput.setCustomValidity("Use a value like 14px, 0.9rem, or 95%.");
@@ -82,8 +53,8 @@
     var existing = document.getElementById("mp-custom-settings");
     if (existing) existing.remove();
 
-    if (family || size) {
-      var css = buildCustomSettingsCss(family, size);
+    if (size) {
+      var css = buildCustomSettingsCss(size);
       var style = document.createElement("style");
       style.setAttribute("id", "mp-custom-settings");
       style.textContent = css;
@@ -91,7 +62,6 @@
     }
   }
 
-  familyInput.addEventListener("input", applySettings);
   sizeInput.addEventListener("change", applySettings);
   sizeInput.addEventListener("blur", applySettings);
 })();

--- a/web/templates/detail.html
+++ b/web/templates/detail.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Request Detail — ManagePrompt</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/style.css">
     <script src="/static/js/apply-settings.js"></script>
 </head>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ManagePrompt</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/style.css">
     <script src="/static/js/apply-settings.js"></script>
 </head>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Settings — ManagePrompt</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/style.css">
     <script src="/static/js/apply-settings.js"></script>
 </head>
@@ -18,10 +15,6 @@
 
             <div class="settings-section">
                 <h3 class="settings-section-title">Appearance</h3>
-                <div class="settings-field">
-                    <label for="font-family">Font family</label>
-                    <input type="text" id="font-family" placeholder="Geist Mono" spellcheck="false" autocomplete="off">
-                </div>
                 <div class="settings-field">
                     <label for="font-size">Font size</label>
                     <input type="text" id="font-size" placeholder="13px" spellcheck="false" autocomplete="off" inputmode="decimal">


### PR DESCRIPTION
## Summary
- migrate the middleware from the LanguageModelV3 contract to LanguageModelV4
- update the Vercel AI SDK and provider development dependencies to their AI SDK 7-compatible releases
- refresh the pnpm lockfile

## Verification
- Rollup ESM, CJS, and declaration build
- TypeScript strict type-check for the SDK and provider examples
- AI SDK 7 runtime smoke test covering both generateText and streamText
- git diff --check